### PR TITLE
시나리오 버튼 생성 완료

### DIFF
--- a/kiosk/client/src/pages/StartPage.js
+++ b/kiosk/client/src/pages/StartPage.js
@@ -5,22 +5,45 @@ import { logClick } from '../api';
 const StartPage = () => {
   const navigate = useNavigate();
   const [username, setUsername] = useState('');
+  const [scenario, setScenario] = useState(''); // 시나리오 선택 상태
 
   const handleClick = () => {
-    if (!username.trim()) return;
+    if (!username.trim() || !scenario) return;
     sessionStorage.setItem('username', username);
-    logClick('StartButton', username); // 사용자 이름 함께 전달
+    sessionStorage.setItem('scenario', scenario); // 선택한 시나리오 저장
+    logClick('StartButton', username);
     navigate('/menu');
   };
 
   return (
     <div className="w-screen min-h-screen bg-cover bg-center flex flex-col items-center justify-center text-white"
          style={{ backgroundImage: `url('/start_bg.jpg')` }}>
-      
+
       <div className="w-full bg-black bg-opacity-70 text-center py-12 px-6">
         <h1 className="text-3xl md:text-5xl font-bold mb-4">
           <span className="text-red-500">광운 식당</span>에<br />오신 걸 환영합니다
         </h1>
+        <p className="text-yellow-400 text-lg md:text-2xl mb-4">
+          먼저 <span className="font-bold">시나리오</span>를 선택해주세요!
+        </p>
+
+        {/* 시나리오 선택 버튼 */}
+        <div className="flex justify-center gap-4 mb-6">
+          <button
+            className={`px-6 py-2 rounded-full text-lg font-semibold border-2 ${scenario === '1' ? 'bg-red-500 border-red-500' : 'border-white'}`}
+            onClick={() => setScenario('1')}
+          >
+            시나리오 1
+          </button>
+          <button
+            className={`px-6 py-2 rounded-full text-lg font-semibold border-2 ${scenario === '2' ? 'bg-red-500 border-red-500' : 'border-white'}`}
+            onClick={() => setScenario('2')}
+          >
+            시나리오 2
+          </button>
+        </div>
+
+        {/* 이름 입력 */}
         <p className="text-yellow-400 text-lg md:text-2xl mb-6">
           아래 <span className="font-bold">이름</span>을 입력하고 <span className="font-bold">[주문하기]</span> 버튼을 눌러주세요!
         </p>
@@ -35,7 +58,7 @@ const StartPage = () => {
         <button
           className="bg-red-600 hover:bg-red-700 text-white text-2xl px-12 py-4 rounded-2xl font-semibold transition disabled:opacity-50"
           onClick={handleClick}
-          disabled={!username.trim()}
+          disabled={!username.trim() || !scenario}
         >
           주문하기
         </button>


### PR DESCRIPTION
- 시작 페이지에 시나리오 선택 버튼 생성
- 시나리오 버튼 생성 후 이름 / 주문하기 버튼을 클릭해야만 메뉴 페이지로 넘어감
- 시나리오1 / 시나리오2 미구현으로 인해 각각의 페이지로 넘어가는 것은 구현 미완

![image](https://github.com/user-attachments/assets/df4f988e-f20e-4c6e-9873-ceac3fb28ff4)
